### PR TITLE
Wrap evalString with parens.

### DIFF
--- a/js/comparison_table.js
+++ b/js/comparison_table.js
@@ -55,12 +55,8 @@
       if (comparator == null) {
         comparator = "===";
       }
-      if (this.asString === "{}") {
-        evalStr = "[" + this.asString + comparator + fc2.asString + "][0]";
-      } else {
-        evalStr = "" + this.asString + comparator + fc2.asString;
-      }
-      return [evalStr, eval(evalStr)];
+      evalStr = "" + this.asString + comparator + fc2.asString;
+      return [evalStr, eval('(' + evalStr + ')')];
     };
 
     ForComparison.prototype.toString = function() {


### PR DESCRIPTION
Prior to this commit, we checked to see if asString was equal to '{}'
because a syntax error would occur during eval on these comparisons. If
we were comparing '{}', we'd wrap it in an array and access index 0 to
get the result of the comparison after eval. Because this requirement is
conditional, we had to modify evalString itself. This had the side
effect of making the 'title' attribute contain the array representation
as well, which is ugly.  Instead, we can wrap every eval'ed string in
parens. This does not change the return value but does mitigate the
syntax error, and it does it in a way that does not change the title
displayed in the table.
