### PR TITLE
Add negative zero

### DIFF
--- a/unified/unified_comparison_table.js
+++ b/unified/unified_comparison_table.js
@@ -77,7 +77,7 @@
   */
 
 
-  values = [true, false, 1, 0, -1, "`'true'`", "`'false'`", "`'1'`", "`'0'`", "`'-1'`", "", "`null`", "`undefined`", "`[]`", "`{}`", [[]], [0], [1], "`parseFloat('nan')`"];
+  values = [true, false, 1, 0, -0, -1, "`'true'`", "`'false'`", "`'1'`", "`'0'`", "`'-1'`", "", "`null`", "`undefined`", "`[]`", "`{}`", [[]], [0], [1], "`parseFloat('nan')`"];
 
   (function() {
     var testRepr;


### PR DESCRIPTION
There are two gotchas that strict equality has, `NaN` and zeroes. Adding negative zero further illustrates that strict equality is not enough and we need [Object.is](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Description).

A further pull request can add `Object.is` to the legend.